### PR TITLE
Fix for disabling remote accelerators to work with latest changes in submodules

### DIFF
--- a/quantum/plugins/ibm/CMakeLists.txt
+++ b/quantum/plugins/ibm/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_libraries(${LIBRARY_NAME}
 )
 
 if(XACC_REMOTE_ACCELERATORS)
-  target_link_libraries(${LIBRARY_NAME} PRIVATE cpr)
+  target_link_libraries(${LIBRARY_NAME} PRIVATE cpr::cpr)
 endif()
 
 set(_bundle_name xacc_ibm)

--- a/xacc/CMakeLists.txt
+++ b/xacc/CMakeLists.txt
@@ -93,6 +93,7 @@ if(MPI_FOUND)
 endif()
 
 if(XACC_REMOTE_ACCELERATORS)
+  target_include_directories(xacc PUBLIC accelerator/remote PRIVATE ${CPR_INCLUDE_DIRS})
   target_link_libraries(xacc PRIVATE cpr::cpr)
 endif()
 


### PR DESCRIPTION
This PR makes sure the latest changes work with disabling remote accelerators. Also, it keeps the most recent push to the `nlopt` repo, which already satisfies the C++ standard issue.